### PR TITLE
UNTESTED Use configured port instead of default.

### DIFF
--- a/mmtr/runner.py
+++ b/mmtr/runner.py
@@ -28,7 +28,7 @@ class Runner(object):
         self.config
         '''
         credentials = pika.PlainCredentials(_configuration.user, _configuration.password)
-        con = pika.ConnectionParameters(host=_configuration.host,
+        con = pika.ConnectionParameters(host=_configuration.host, port=_configuration.port,
                                         credentials=credentials)
         connection = pika.BlockingConnection(con)
         self.channel = connection.channel()


### PR DESCRIPTION
Hey @trenton42 I think this is what's needed so Honeybee plays nice with Nomad.

Theoretically, Nomad should be able to serve RabbitMQ over static ports. I couldn't get it to cooperate in the short time I had, but I could try again if it's too painful to build Honeybee.

I haven't tested this yet (I haven't successfully built Honeybee).